### PR TITLE
Immediately redraw tags after adding a new tag

### DIFF
--- a/eclipse project (deprecated)/src/me/kaede/tagview/TagView.java
+++ b/eclipse project (deprecated)/src/me/kaede/tagview/TagView.java
@@ -285,6 +285,7 @@ public class TagView extends RelativeLayout {
 	 */
 	public void add(Tag tag) {
 		mTags.add(tag);
+		drawTags();
 	}
 
 	/**


### PR DESCRIPTION
Actually, the Android Studio version of this library does the `drawTags()` in `addTag()`. Without the `drawTags()`, `addTag()` only updates internal data while leaves UI unchanged.
