### PR TITLE
Fix bug: TagView with deletableView

### DIFF
--- a/library/src/main/java/me/kaede/tagview/TagView.java
+++ b/library/src/main/java/me/kaede/tagview/TagView.java
@@ -237,7 +237,7 @@ public class TagView extends RelativeLayout {
 			//add margin of each line
 			tagParams.bottomMargin = lineMargin;
 
-			if (mWidth <= total + tagWidth + Utils.dpToPx(this.getContext(), Constants.LAYOUT_WIDTH_OFFSET)) {
+			if (mWidth <= total + tagMargin + tagWidth + Utils.dpToPx(this.getContext(), Constants.LAYOUT_WIDTH_OFFSET)) {
 				//need to add in new line
 				tagParams.addRule(RelativeLayout.BELOW, index_bottom);
 				// initialize total param (layout padding left & layout padding right)

--- a/library/src/main/java/me/kaede/tagview/TagView.java
+++ b/library/src/main/java/me/kaede/tagview/TagView.java
@@ -225,7 +225,7 @@ public class TagView extends RelativeLayout {
 						}
 					}
 				});
-				tagWidth += deletableView.getPaint().measureText(tag.deleteIcon) + textPaddingLeft + textPaddingRight;
+				tagWidth += deletableView.getPaint().measureText(tag.deleteIcon) + deletableView.getPaddingLeft() + deletableView.getPaddingRight();
 				// deletableView Padding (left & right)
 			} else {
 				deletableView.setVisibility(View.GONE);


### PR DESCRIPTION
`TagView` with `deletableView` will make a new line too early, since `tagWidth` is calculated in mistake.
In line 228, there should be `+ offset + (textPaddingRight + offset)` instead of `+ textPaddingLeft + textPaddingRight`.
Dynamically get `PaddingLeft` and `PaddingRight` of `deletableView`, so you can change it's padding in future without modify this code snippet.
